### PR TITLE
add CATCH_TEST_FAIL

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1248,7 +1248,13 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
     if (TEST_PROTECT())
     {
         setUp();
-        Func();
+        if (CATCH_TEST_FAIL()) {
+            UnityTestResultsFailBegin(42);
+            UnityAddMsgIfSpecified("TEST_FAIL called");
+            UNITY_FAIL_AND_BAIL;
+        } else {
+            Func();
+        }
     }
     if (TEST_PROTECT() && !(Unity.CurrentTestIgnored))
     {

--- a/src/unity.h
+++ b/src/unity.h
@@ -287,6 +287,7 @@ extern jmp_buf __unity_exp_buf__;
 #define TEST_CATCH } else {
 #define TEST_ETRY } } while(0)
 #define TEST_THROW longjmp(__unity_exp_buf__, 1)
+#define CATCH_TEST_FAIL() (setjmp(__unity_exp_buf__) != 0)
 
 // Refactor to make this easier to manage
 #define TEST_SHOULD_CATCH_ASSERT(actual)                  \


### PR DESCRIPTION
@leftbyte FYI, this is not complete but a working proof of concept

with this the `test_store_rx_keys` from https://github.com/OnBeep/obfw/pull/879 fails properly,

```
test/test_crypto.cpp:446:test_set_get_tx_rx_keys:PASS
test/test_crypto.cpp:42:test_store_rx_keys:FAIL:. TEST_FAIL called
test/test_crypto.cpp:448:test_encryptpacket_verify_ciphertext:PASS
...
-----------------------
13 Tests 1 Failures 0 Ignored 
FAIL
```
